### PR TITLE
A few tweaks to docstrings and code. Add more tests.

### DIFF
--- a/src/FieldTraits.jl
+++ b/src/FieldTraits.jl
@@ -4,10 +4,12 @@ module FieldTraits
 using Compat, MacroTools
 using Compat.TypeUtils
 
-import Base: @propagate_inbounds, @pure, tail, haskey, getindex, setindex!, get
-import Base: is_linenumber, convert, (==), get!
+using Base: @propagate_inbounds, @pure, tail, is_linenumber
+import Base: (==), haskey, getindex, setindex!, get, get!, convert
 
 @compat abstract type Composable end
+
+export @field, @composed, @reactivecomposed, @needs, Fields
 
 include("composedtype.jl")
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,23 @@
+using FieldTraits, Base.Test
+
+"`zap(x)` sends `x` to oblivion" zap(x) = nothing
+
+@testset "UsageError" begin
+    ue = FieldTraits.UsageError(zap, 2)
+    @test ue.message == "`zap(x)` sends `x` to oblivion\n"
+    @test ue.value == 2
+    ue = FieldTraits.UsageError("a custom error message", 2)
+    @test ue.message == "a custom error message"
+end
+
+@field FIscale
+@field FIposition
+@field FInotfield
+@composed type FIcomposed
+    FIscale
+    FIposition
+end
+@testset "fieldindex" begin
+    @test FieldTraits.fieldindex(FIcomposed, FIposition) === (Val{2}(),)
+    @test FieldTraits.fieldindex(FIcomposed, FInotfield) === (Val{0}(),)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using FieldTraits, Quaternions, Colors
 using Base.Test
-import FieldTraits: @field, @composed, @reactivecomposed, Fields, default
+
+include("core.jl")
 
 @field ImageData
 
@@ -49,7 +50,7 @@ function Base.convert(::Type{SpatialOrder}, parent, value)
     value == :xy ? (1, 2) : (2, 1)
 end
 
-function default(x, ::Type{Ranges})
+function FieldTraits.default(x, ::Type{Ranges})
     data = x[ImageData]
     s = get(x, SpatialOrder) # if SpatialOrder in x, gets that, if not gets default(x, SpatialOrder)
     (0:size(data, s[1]), 0:size(data, s[2]))


### PR DESCRIPTION
I finally got a chance to start reviewing this repo. It seems useful and promising.

This is about as far as I could get today, but this PR contains a few tweaks. Most importantly, I used a more standard format for docstrings (it's customary to show how you use the function on the first line), and fixed at least one bug.

I also added some exports. I don't know whether their absence was intended or not, but I was keying off the README at Visualize and assumed it was an oversight. (Note also that the `@composable Surface` demo is missing the word `type`.)
